### PR TITLE
feat(meta): add meta files also for dist version, #21

### DIFF
--- a/DIST-README.md
+++ b/DIST-README.md
@@ -1,0 +1,11 @@
+# zalando.github.io 
+
+Zalando github io page **DIST** repository.
+
+[![Build Status](https://travis-ci.org/zalando/zalando.github.io-dev.svg?branch=dev)](https://travis-ci.org/zalando/zalando.github.io-dev)
+
+**DISCLAIMER: This repo is just the result of build/deploy. To contribute to development, open new issues... etc. Please go to: [https://github.com/zalando/zalando.github.io-dev](https://github.com/zalando/zalando.github.io-dev)**
+
+## LICENSE
+
+See the [LICENSE file](LICENSE)

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Zalando SE
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Ruben Barilani <ruben.barilani@zalando.de>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -23,8 +23,8 @@ var gulp = require('gulp'),
     reload = browserSync.reload,
     imagemin = require('gulp-imagemin'),
     pngquant = require('imagemin-pngquant'),
-    ghPages = require('gulp-gh-pages'),
     assign = require('object-assign'),
+    rename = require('gulp-rename'),
     fs = require('fs'),
     _ = require('lodash'),
     p = {
@@ -152,8 +152,21 @@ gulp.task('start', ['clean','parameters'], function() {
   runSequence(['watch', 'watchify', 'styles', 'images', 'fonts'], 'browserSync');
 });
 
-gulp.task('copy-dist', function () {
+gulp.task('copy-dist', ['copy-dist-metafiles','copy-dist-readme'], function () {
   return gulp.src(['.tmp/**/*','src/index.html']).pipe(gulp.dest(p.dist));
+});
+
+gulp.task('copy-dist-metafiles', function () {
+  return gulp
+    .src(['LICENSE','MAINTAINERS'])
+    .pipe(gulp.dest(p.dist));
+});
+
+gulp.task('copy-dist-readme', function () {
+  return gulp
+    .src(['DIST-README.md'])
+    .pipe(rename('README.md'))
+    .pipe(gulp.dest(p.dist));
 });
 
 /**

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10363,6 +10363,11 @@
         }
       }
     },
+    "gulp-rename": {
+      "version": "1.2.2",
+      "from": "gulp-rename@*",
+      "resolved": "https://registry.npmjs.org/gulp-rename/-/gulp-rename-1.2.2.tgz"
+    },
     "gulp-sass": {
       "version": "2.0.4",
       "from": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-2.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "gulp-imagemin": "^2.3.0",
     "gulp-notify": "^2.2.0",
     "gulp-postcss": "^5.1.9",
+    "gulp-rename": "^1.2.2",
     "gulp-sass": "^2.0.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-uglify": "^1.2.0",


### PR DESCRIPTION
@hjacobs This should fix #21. Please review it. The DIST-README file will appear in the zalando.github.io offical repo as the README, same for LICENSE and MAINTAINERS files.
