### PR TITLE
chore(config): point catwatch to Kubernetes cluster

### DIFF
--- a/src/config/parameters.default.json
+++ b/src/config/parameters.default.json
@@ -1,6 +1,6 @@
 {
   "CATWATCH_API": {
-    "BASE_URL": "catwatch.opensource.zalan.do",
+    "BASE_URL": "catwatch.stups.zalan.do",
     "PROTOCOL": "https",
     "ORGANIZATIONS": "zalando"
   }


### PR DESCRIPTION
Don't merge yet, please.

We deployed Catwatch on the TI Kubernetes cluster (stups). It's available at https://catwatch.stups.zalan.do/ and should be a full replacement for the one running at https://catwatch.opensource.zalan.do.