### PR TITLE
Revert "chore(config): point catwatch to Kubernetes cluster"

### DIFF
--- a/src/config/parameters.default.json
+++ b/src/config/parameters.default.json
@@ -1,6 +1,6 @@
 {
   "CATWATCH_API": {
-    "BASE_URL": "catwatch.stups.zalan.do",
+    "BASE_URL": "catwatch.opensource.zalan.do",
     "PROTOCOL": "https",
     "ORGANIZATIONS": "zalando"
   }


### PR DESCRIPTION
Reverts zalando-incubator/zalando.github.io-dev#68

Cause: 

```
GET https://catwatch.stups.zalan.do/projects?organizations=zalando&limit=6&offset=0&sortBy=-score
```

The response contains duplicates.