### PR TITLE
jquery cve fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "flux": "^2.1.1",
     "imagemin-pngquant": "^4.2.2",
     "jest-cli": "^11.0.2",
-    "jquery": "^2.2.1",
+    "jquery": "^3.0.0",
     "lodash": "^4.6.1",
     "numeral": "^1.5.3",
     "object-assign": "^4.0.1",


### PR DESCRIPTION
Triggered by gh vulnerability notification:

![screenshot_2018-01-24_22-41-45](https://user-images.githubusercontent.com/1148268/35358850-5617eb22-0158-11e8-9e58-79dcc70c3758.jpg)

https://nvd.nist.gov/vuln/detail/CVE-2015-9251 should not be so serious anymore. Future updates regarding https://nvd.nist.gov/vuln/detail/CVE-2016-10707 might be needed.